### PR TITLE
Make addons recognize a version string

### DIFF
--- a/manifests/addon.pp
+++ b/manifests/addon.pp
@@ -42,6 +42,7 @@
 #
 define splunk::addon (
   Optional[Stdlib::Absolutepath] $splunk_home = undef,
+  Optional[String[1]] $version                = undef,
   Boolean $package_manage                     = true,
   Optional[String[1]] $splunkbase_source      = undef,
   Optional[String[1]] $package_name           = undef,
@@ -70,6 +71,12 @@ define splunk::addon (
 
   if $package_manage {
     if $splunkbase_source {
+
+      if $version {
+        $addon_creates = "${_splunk_home}/etc/apps/${name}/manifest-${version}"
+      } else {
+        $addon_creates = "${_splunk_home}/etc/apps/${name}"
+      }
       $archive_name = $splunkbase_source.split('/')[-1]
       archive { $name:
         path         => "${splunk::params::staging_dir}/${archive_name}",
@@ -78,7 +85,7 @@ define splunk::addon (
         source       => $splunkbase_source,
         extract      => true,
         extract_path => "${_splunk_home}/etc/apps",
-        creates      => "${_splunk_home}/etc/apps/${name}",
+        creates      => "${addon_creates}",
         cleanup      => true,
         before       => File["${_splunk_home}/etc/apps/${name}/local"],
       }
@@ -122,4 +129,3 @@ define splunk::addon (
     }
   }
 }
-


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Allow user to pass a version string to indicate if the add-on should be updated. If used, a manifest file will be included in the root of the add-on directory

#### This Pull Request (PR) fixes the following issues
n/a